### PR TITLE
fix for breaking iOS header change in RN 0.40.0

### DIFF
--- a/ios/RNVersionNumber.h
+++ b/ios/RNVersionNumber.h
@@ -1,5 +1,5 @@
 
-#import "RCTBridgeModule.h"
+#import <React/RCTBridgeModule.h>
 
 @interface RNVersionNumber : NSObject <RCTBridgeModule>
 

--- a/ios/RNVersionNumber.h
+++ b/ios/RNVersionNumber.h
@@ -1,5 +1,8 @@
-
+#if __has_include(<React/RCTBridgeModule.h>)
 #import <React/RCTBridgeModule.h>
+#else
+#import "RCTBridgeModule.h"
+#endif
 
 @interface RNVersionNumber : NSObject <RCTBridgeModule>
 


### PR DESCRIPTION
In latest (0.40) React Native release they have namespaced the header files.

https://github.com/facebook/react-native/releases/tag/v0.40.0