### PR TITLE
Support RN 0.47 on Android

### DIFF
--- a/android/src/main/java/com/apsl/versionnumber/RNVersionNumberPackage.java
+++ b/android/src/main/java/com/apsl/versionnumber/RNVersionNumberPackage.java
@@ -17,7 +17,7 @@ public class RNVersionNumberPackage implements ReactPackage {
       return Arrays.<NativeModule>asList(new RNVersionNumberModule(reactContext));
     }
 
-    @Override
+    // Deprecated in RN 0.47 - facebook/react-native@ce6fb33
     public List<Class<? extends JavaScriptModule>> createJSModules() {
       return Collections.emptyList();
     }


### PR DESCRIPTION
RN 0.47 introduces a breaking change to createJSModules:
facebook/react-native@ce6fb33