### PR TITLE
Add `bundleIdentifier` support to Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 # react-native-version-number
 <img src="https://travis-ci.org/APSL/react-native-version-number.svg?branch=master" />
 
-Returns the `CFBundleShortVersionString` and the `CFBundleVersion` and `bundleIdentifier` on IOS. For Android, returns the `versionName` and `versionCode`.
+Returns the `CFBundleShortVersionString` and the `CFBundleVersion` and `bundleIdentifier` on IOS. For Android, returns the `versionName`, `versionCode` and `applicationId`.
 
 
 |  | iOS | Android | Example |
 | --- | --- | --- | --- |
 | appVersion | `CFBundleShortVersionString` | `versionName` | `1.0.2` |
 | buildVersion | `CFBundleVersion` | `versionCode` | `42` |
-| bundleIdentifier | `bundleIdentifier` | | `com.foo.bar.MyApp`|
+| bundleIdentifier | `bundleIdentifier` | `applicationId` | `com.foo.bar.MyApp`|
 
 
 ## Getting started
@@ -28,8 +28,7 @@ import VersionNumber from 'react-native-version-number';
 
 console.log(VersionNumber.appVersion);
 console.log(VersionNumber.buildVersion);
-
-console.log(VersionNumber.bundleIdentifier); // iOS only
+console.log(VersionNumber.bundleIdentifier);
 
 ```
 

--- a/android/src/main/java/com/apsl/versionnumber/RNVersionNumberModule.java
+++ b/android/src/main/java/com/apsl/versionnumber/RNVersionNumberModule.java
@@ -19,6 +19,7 @@ public class RNVersionNumberModule extends ReactContextBaseJavaModule {
 
   private static final String APP_VERSION = "appVersion";
   private static final String APP_BUILD = "buildVersion";
+  private static final String APP_ID = "bundleIdentifier";
 
   public RNVersionNumberModule(ReactApplicationContext reactContext) {
     super(reactContext);
@@ -38,6 +39,7 @@ public class RNVersionNumberModule extends ReactContextBaseJavaModule {
     try {
       constants.put(APP_VERSION, packageManager.getPackageInfo(packageName, 0).versionName);
       constants.put(APP_BUILD, packageManager.getPackageInfo(packageName, 0).versionCode);
+      constants.put(APP_ID, packageName);
     } catch (NameNotFoundException e) {
       e.printStackTrace();
     }

--- a/index.js
+++ b/index.js
@@ -6,13 +6,14 @@ const { RNVersionNumber } = NativeModules;
 
 type VersionObject = {
   appVersion: string,
-  buildVersion: string
-}
+  buildVersion: string,
+  bundleIdentifier: string,
+};
 
 const VersionNumber: VersionObject = {
   appVersion: RNVersionNumber.appVersion,
   buildVersion: RNVersionNumber.buildVersion,
-  bundleIdentifier: RNVersionNumber.bundleIdentifier
-}
+  bundleIdentifier: RNVersionNumber.bundleIdentifier,
+};
 
 export default VersionNumber;


### PR DESCRIPTION
This PR unifies the API for iOS & Android by adding the `bundleIdentifier` option to Android. I've opted to return the `applicationId` contained in the users gradle settings as this is analogous to the bundle identifier on iOS.