### PR TITLE
Fix Android gradle build script

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,13 +1,16 @@
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
 
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion safeExtGet('compileSdkVersion', 26)
+    buildToolsVersion safeExtGet('buildToolsVersion', '26.0.3')
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 22
+        minSdkVersion safeExtGet('minSdkVersion', 16)
+        targetSdkVersion safeExtGet('targetSdkVersion', 26)
         versionCode 1
         versionName "1.0"
         ndk {


### PR DESCRIPTION
This is similar to #27 but use a cleaner way to achieve the same result.

As of 0.56, we RN proj start declaring a few constants that libraries can query about.

Some library uses this technique so I'm porting it over here:

- https://github.com/oblador/react-native-vector-icons/blob/master/android/build.gradle
- https://github.com/oney/react-native-webrtc/pull/494/files