### PR TITLE
feature: add installationSource to identify test versions and sideloaded apps

### DIFF
--- a/android/src/main/java/com/apsl/versionnumber/RNVersionNumberModule.java
+++ b/android/src/main/java/com/apsl/versionnumber/RNVersionNumberModule.java
@@ -20,6 +20,7 @@ public class RNVersionNumberModule extends ReactContextBaseJavaModule {
   private static final String APP_VERSION = "appVersion";
   private static final String APP_BUILD = "buildVersion";
   private static final String APP_ID = "bundleIdentifier";
+  private static final String APP_INSTALLATION_SOURCE = "installationSource";
 
   public RNVersionNumberModule(ReactApplicationContext reactContext) {
     super(reactContext);
@@ -39,6 +40,7 @@ public class RNVersionNumberModule extends ReactContextBaseJavaModule {
     try {
       constants.put(APP_VERSION, packageManager.getPackageInfo(packageName, 0).versionName);
       constants.put(APP_BUILD, packageManager.getPackageInfo(packageName, 0).versionCode);
+      constants.put(APP_INSTALLATION_SOURCE, packageManager.getInstallerPackageName());
       constants.put(APP_ID, packageName);
     } catch (NameNotFoundException e) {
       e.printStackTrace();

--- a/android/src/main/java/com/apsl/versionnumber/RNVersionNumberModule.java
+++ b/android/src/main/java/com/apsl/versionnumber/RNVersionNumberModule.java
@@ -40,7 +40,7 @@ public class RNVersionNumberModule extends ReactContextBaseJavaModule {
     try {
       constants.put(APP_VERSION, packageManager.getPackageInfo(packageName, 0).versionName);
       constants.put(APP_BUILD, packageManager.getPackageInfo(packageName, 0).versionCode);
-      constants.put(APP_INSTALLATION_SOURCE, packageManager.getInstallerPackageName());
+      constants.put(APP_INSTALLATION_SOURCE, packageManager.getInstallerPackageName(packageName));
       constants.put(APP_ID, packageName);
     } catch (NameNotFoundException e) {
       e.printStackTrace();

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,4 +2,5 @@ declare module 'react-native-version-number' {
   export const appVersion: string
   export const buildVersion: string
   export const bundleIdentifier: string
+  export const installationSource: string
 }

--- a/index.js
+++ b/index.js
@@ -7,12 +7,14 @@ const { RNVersionNumber } = NativeModules;
 type VersionObject = {
   appVersion: ?string,
   buildVersion: ?string,
+  installationSource: ?string,
   bundleIdentifier: ?string
 };
 
 const VersionNumber: VersionObject = {
   appVersion: RNVersionNumber && RNVersionNumber.appVersion,
   buildVersion: RNVersionNumber && RNVersionNumber.buildVersion,
+  installationSource: RNVersionNumber && RNVersionNumber.installationSource,
   bundleIdentifier: RNVersionNumber && RNVersionNumber.bundleIdentifier
 };
 

--- a/ios/RNVersionNumber.m
+++ b/ios/RNVersionNumber.m
@@ -11,9 +11,14 @@ RCT_EXPORT_MODULE()
 
 - (NSDictionary *)constantsToExport
 {
+    NSString* receipt = [[[NSBundle mainBundle] appStoreReceiptURL] path];
+    #if TARGET_IPHONE_SIMULATOR
+        NSLog(@"Running on the Device, installationSource might not be able to be detected. Should only happen on Xcode versions running the app with Rosetta");
+        receipt = receipt != nil ? receipt : @"file:///private/var/mobile/Containers/Data/CoreSimulator/Application/FAKE_M1_Rosetta_Fallback/StoreKit/sandboxReceipt";
+    #endif
     return @{@"appVersion"  : [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"],
              @"buildVersion": [[NSBundle mainBundle] objectForInfoDictionaryKey:(NSString *)kCFBundleVersionKey],
-             @"installationSource"  : [[[NSBundle mainBundle] appStoreReceiptURL] path],
+             @"installationSource"  : receipt,
              @"bundleIdentifier"  : [[NSBundle mainBundle] bundleIdentifier]
             };
            

--- a/ios/RNVersionNumber.m
+++ b/ios/RNVersionNumber.m
@@ -13,6 +13,7 @@ RCT_EXPORT_MODULE()
 {
     return @{@"appVersion"  : [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"],
              @"buildVersion": [[NSBundle mainBundle] objectForInfoDictionaryKey:(NSString *)kCFBundleVersionKey],
+             @"installationSource"  : [[[NSBundle mainBundle] appStoreReceiptURL] path],
              @"bundleIdentifier"  : [[NSBundle mainBundle] bundleIdentifier]
             };
            

--- a/react-native-version-number.podspec
+++ b/react-native-version-number.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license        = package_json["license"]
   s.author         = { package_json["author"] => package_json["author"] }
   s.platform       = :ios, "7.0"
-  s.source         = { :git => "#{package_json["repository"]["url"]}.git", :tag => "v#{s.version}" }
+  s.source         = { :git => "#{package_json["repository"]["url"]}" }
   s.source_files   = 'ios/*.{h,m}'
   s.dependency 'React'
 


### PR DESCRIPTION
This additional exported information can tell how the app came to be installed on the device. We use it to differentiate between App Store / Play Store versions and their TestFlight / Hockeyapp counterparts.

Example code would look something like this:
```js
const isTestFlightOrSimulator =
  !!installationSource &&
  (installationSource.indexOf('sandboxReceipt') !== -1 ||
    installationSource.indexOf('CoreSimulator') !== -1)

const isAndroidBeta =
  !installationSource ||
  installationSource.indexOf('com.android.vending') === -1
```