### PR TITLE
Allow pass the minSdkVersion based from project

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,13 +4,14 @@ apply plugin: 'com.android.library'
 def DEFAULT_COMPILE_SDK_VERSION = 27
 def DEFAULT_BUILD_TOOLS_VERSION = "27.0.3"
 def DEFAULT_TARGET_SDK_VERSION = 27
+def DEFAULT_MIN_SDK_VERSION = 16
 
 android {
     compileSdkVersion project.hasProperty('compileSdkVersion') ? project.compileSdkVersion : DEFAULT_COMPILE_SDK_VERSION
     buildToolsVersion project.hasProperty('buildToolsVersion') ? project.buildToolsVersion : DEFAULT_BUILD_TOOLS_VERSION
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion project.hasProperty('minSdkVersion') ? project.minSdkVersion : DEFAULT_MIN_SDK_VERSION
         targetSdkVersion project.hasProperty('targetSdkVersion') ? project.targetSdkVersion : DEFAULT_TARGET_SDK_VERSION
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
As per https://github.com/wix/Detox/issues/2712 the 0.64.* requires `minSdkVersion` 21.