### PR TITLE
Fix export type - updated to default export in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,9 @@
 declare module 'react-native-version-number' {
-  export const appVersion: string
-  export const buildVersion: string
-  export const bundleIdentifier: string
+  const VersionNumber = {
+    appVersion: string,
+    buildVersion: string,
+    bundleIdentifier: string 
+  }
+
+  export default VersionNumber;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 declare module 'react-native-version-number' {
-  const VersionNumber = {
+  const VersionNumber: {
     appVersion: string,
     buildVersion: string,
     bundleIdentifier: string 


### PR DESCRIPTION
Currently the type is wrong for index.d.ts as index.js doesn't export `const`'s but rather one `default` export with the VersionNumber